### PR TITLE
Allow JSON payload in request body

### DIFF
--- a/lib/curl.php
+++ b/lib/curl.php
@@ -170,8 +170,8 @@ class Curl {
         $this->request = curl_init();
 
         $json_payload = '';
-        if (strtolower('get') != 'get') {
-            foreach ($headers as $key => $value) {
+        if (strtolower($method) != 'get') {
+            foreach ($this->headers as $key => $value) {
                 if (strtolower($value) == 'application/json') {
                     $json_payload = json_encode($vars);
                 }

--- a/lib/curl.php
+++ b/lib/curl.php
@@ -168,7 +168,23 @@ class Curl {
     function request($method, $url, $vars = array()) {
         $this->error = '';
         $this->request = curl_init();
-        if (is_array($vars)) $vars = http_build_query($vars, '', '&');
+
+        $json_payload = '';
+        if (strtolower('get') != 'get') {
+            foreach ($headers as $key => $value) {
+                if (strtolower($value) == 'application/json') {
+                    $json_payload = json_encode($vars);
+                }
+            }
+        }
+
+        if (is_array($vars)) {
+            if ($json_payload == '') {
+                $vars = http_build_query($vars, '', '&');
+            }else {
+                $vars = $json_payload;
+            }
+        }
         
         $this->set_request_method($method);
         $this->set_request_options($url, $vars);


### PR DESCRIPTION
Used `json_encode($vars)` for all requests that specify `content-type: application/json` in their header params. 

The lib failed when posting JSON payload so i added a fix to `json_encode($body)` all requests that has `content-type: application/json` in their header.